### PR TITLE
Feat: add generate stream with delta

### DIFF
--- a/boson_multimodal/model/higgs_audio/utils.py
+++ b/boson_multimodal/model/higgs_audio/utils.py
@@ -88,24 +88,22 @@ def build_delay_pattern_mask(
     return input_ids, input_ids_with_gen_mask
 
 
-def revert_delay_pattern(data, start_idx=0):
+def revert_delay_pattern(data):
     """Convert samples encoded with delay pattern back to the original form.
 
     Args:
         data (:obj:`torch.Tensor`):
             The data with delay pattern applied. It will have shape (num_codebooks, seq_len + num_codebooks - 1).
-        start_idx (:obj:`int`): start index for the delay pattern.
 
     Returns:
         ret (:obj:`torch.Tensor`):
             Recovered data with delay pattern removed. It will have shape (num_codebooks, seq_len).
     """
     assert len(data.shape) == 2
-    assert data.shape[1] - data.shape[0] >= start_idx
     out_l = []
     num_codebooks = data.shape[0]
     for i in range(num_codebooks):
-        out_l.append(data[i : (i + 1), i + start_idx : (data.shape[1] - num_codebooks + 1 + i)])
+        out_l.append(data[i : (i + 1), i : (data.shape[1] - num_codebooks + 1 + i)])
     return torch.cat(out_l, dim=0)
 
 

--- a/boson_multimodal/model/higgs_audio/utils.py
+++ b/boson_multimodal/model/higgs_audio/utils.py
@@ -88,22 +88,24 @@ def build_delay_pattern_mask(
     return input_ids, input_ids_with_gen_mask
 
 
-def revert_delay_pattern(data):
+def revert_delay_pattern(data, start_idx=0):
     """Convert samples encoded with delay pattern back to the original form.
 
     Args:
         data (:obj:`torch.Tensor`):
             The data with delay pattern applied. It will have shape (num_codebooks, seq_len + num_codebooks - 1).
+        start_idx (:obj:`int`): start index for the delay pattern.
 
     Returns:
         ret (:obj:`torch.Tensor`):
             Recovered data with delay pattern removed. It will have shape (num_codebooks, seq_len).
     """
     assert len(data.shape) == 2
+    assert data.shape[1] - data.shape[0] >= start_idx
     out_l = []
     num_codebooks = data.shape[0]
     for i in range(num_codebooks):
-        out_l.append(data[i : (i + 1), i : (data.shape[1] - num_codebooks + 1 + i)])
+        out_l.append(data[i : (i + 1), i + start_idx : (data.shape[1] - num_codebooks + 1 + i)])
     return torch.cat(out_l, dim=0)
 
 

--- a/boson_multimodal/serve/serve_engine.py
+++ b/boson_multimodal/serve/serve_engine.py
@@ -460,7 +460,11 @@ class HiggsAudioServeEngine:
 
             self._prepare_kv_caches()
 
-            streamer = AsyncHiggsAudioStreamer(self.tokenizer, skip_prompt=True)
+            streamer = AsyncHiggsAudioStreamer(
+                self.tokenizer,
+                audio_num_codebooks=self.model.config.audio_num_codebooks,
+                skip_prompt=True,
+            )
             generation_kwargs = dict(
                 **inputs,
                 max_new_tokens=max_new_tokens,

--- a/boson_multimodal/serve/serve_engine.py
+++ b/boson_multimodal/serve/serve_engine.py
@@ -107,7 +107,8 @@ class AsyncHiggsAudioStreamer(BaseStreamer):
             # This is likely audio tokens (shape: [audio_num_codebooks])
             assert value.shape[0] == self.audio_num_codebooks, "Number of codebooks mismatch"
             delta = HiggsAudioStreamerDelta(audio_tokens=value)
-            self.loop.call_soon_threadsafe(self.queue.put_nowait, delta)
+            if self.loop.is_running():
+                self.loop.call_soon_threadsafe(self.queue.put_nowait, delta)
             return
 
         # Skip prompt tokens if configured
@@ -121,12 +122,14 @@ class AsyncHiggsAudioStreamer(BaseStreamer):
 
         text = self.tokenizer.decode(value, **self.decode_kwargs)
         delta = HiggsAudioStreamerDelta(text=text, text_tokens=value)
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, delta)
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.queue.put_nowait, delta)
 
     def end(self):
         """Flushes any remaining text tokens and signals the end of generation."""
         self.next_tokens_are_prompt = True
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, self.stop_signal)
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.queue.put_nowait, self.stop_signal)
 
     def __aiter__(self):
         return self

--- a/boson_multimodal/serve/serve_engine.py
+++ b/boson_multimodal/serve/serve_engine.py
@@ -421,3 +421,64 @@ class HiggsAudioServeEngine:
                     "cached_tokens": 0,
                 },
             )
+
+    async def generate_delta_stream(
+        self,
+        chat_ml_sample: ChatMLSample,
+        max_new_tokens: int,
+        temperature: float = 0.7,
+        top_k: Optional[int] = None,
+        top_p: float = 0.95,
+        stop_strings: Optional[List[str]] = None,
+        force_audio_gen: bool = False,
+        ras_win_len: Optional[int] = 7,
+        ras_win_max_num_repeat: int = 2,
+        seed: Optional[int] = None,
+    ):
+        """
+        Generate audio from a chatml sample.
+        Args:
+            chat_ml_sample: A chatml sample.
+            max_new_tokens: The maximum number of new tokens to generate.
+            temperature: The temperature to use for the generation.
+            top_p: The top p to use for the generation.
+            stop_strings: A list of strings to stop the generation.
+            force_audio_gen: Whether to force audio generation. This ensures the model generates audio tokens rather than text tokens.
+            ras_win_len: The length of the RAS window. We use 7 by default. You can disable it by setting it to None or <=0.
+            ras_win_max_num_repeat: The maximum number of times to repeat the RAS window.
+        Returns:
+             Delta AsyncGenerator
+        """
+        # Default stop strings
+        if stop_strings is None:
+            stop_strings = ["<|end_of_text|>", "<|eot_id|>"]
+        if ras_win_len is not None and ras_win_len <= 0:
+            ras_win_len = None
+
+        with torch.no_grad():
+            inputs = self._prepare_inputs(chat_ml_sample, force_audio_gen=force_audio_gen)
+
+            self._prepare_kv_caches()
+
+            streamer = AsyncHiggsAudioStreamer(self.tokenizer, skip_prompt=True)
+            generation_kwargs = dict(
+                **inputs,
+                max_new_tokens=max_new_tokens,
+                use_cache=True,
+                stop_strings=stop_strings,
+                tokenizer=self.tokenizer,
+                do_sample=False if temperature == 0.0 else True,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                past_key_values_buckets=self.kv_caches,
+                ras_win_len=ras_win_len,
+                ras_win_max_num_repeat=ras_win_max_num_repeat,
+                seed=seed,
+                streamer=streamer,
+            )
+            thread = threading.Thread(target=self.model.generate, kwargs=generation_kwargs)
+            thread.start()
+
+            async for delta in streamer:
+                yield delta


### PR DESCRIPTION
demo:

```python
import os

import torch
import soundfile
import numpy as np
from loguru import logger

from boson_multimodal.serve.serve_engine import (
    HiggsAudioServeEngine,
)
from boson_multimodal.data_types import ChatMLSample, Message


def revert_delay_pattern(data, start_idx=0):
    """Convert samples encoded with delay pattern back to the original form.

    Args:
        data (:obj:`torch.Tensor`):
            The data with delay pattern applied. It will have shape (num_codebooks, seq_len + num_codebooks - 1).

    Returns:
        ret (:obj:`torch.Tensor`):
            Recovered data with delay pattern removed. It will have shape (num_codebooks, seq_len).
    """
    assert len(data.shape) == 2
    assert data.shape[1] - data.shape[0] >= start_idx
    out_l = []
    num_codebooks = data.shape[0]
    for i in range(num_codebooks):
        out_l.append(data[i : (i + 1), i + start_idx : (data.shape[1] - num_codebooks + 1 + i)])
    return torch.cat(out_l, dim=0)


async def audio_generate_stream(**kwargs):
    ASSETS_DIR="./assets"
    HF_MODEL_DIR = "./ckpt"
    MODEL_PATH = os.getenv("LLM_MODEL", "bosonai/higgs-audio-v2-generation-3B-base")
    AUDIO_TOKENIZER_PATH = os.getenv("AUDIO_TOKENIZER_PATH", "bosonai/higgs-audio-v2-tokenizer")
    model_path = os.path.join(HF_MODEL_DIR, MODEL_PATH)
    audio_tokenizer_path = os.path.join(HF_MODEL_DIR, AUDIO_TOKENIZER_PATH)
    device = "cuda" if torch.cuda.is_available() else "cpu"

    serve_engine = HiggsAudioServeEngine(
        model_path,
        audio_tokenizer_path,
        device=device,
        torch_dtype=torch.bfloat16,
    )

    system_prompt = "Generate audio following instruction.\n\n<|scene_desc_start|>\nAudio is recorded from a quiet room.\n<|scene_desc_end|>"

    messages = [
        Message(
            role="system",
            content=system_prompt,
        ),
        Message(
            role="user",
            content="The sun rises in the east and sets in the west. This simple fact has been observed by humans for thousands of years.",
            # content="太阳东升西落。这个简单的现象，人类已经观察了数千年。",
            # content="好",
        ),
    ]
    for i in range(1):
        logger.info(f"{i} Starting generation...")
        # output = serve_engine.generate_stream(
        output = serve_engine.generate_delta_stream(
            chat_ml_sample=ChatMLSample(messages=messages),
            max_new_tokens=1024,
            temperature=0.3,
            top_p=0.95,
            top_k=50,
            stop_strings=["<|end_of_text|>", "<|eot_id|>"],
        )

        audio_tokens = []
        audio_tensor = None
        CHUNK_SIZE = 16
        seq_len = 0
        waveform_list = []

        chunk_overlap_duration = kwargs.get("chunk_overlap_duration", 0.04)
        cross_fade_samples = int(
            chunk_overlap_duration * serve_engine.audio_tokenizer.sampling_rate
        )
        fade_out = np.linspace(1, 0, cross_fade_samples)
        fade_in = np.linspace(0, 1, cross_fade_samples)

        with torch.inference_mode():
            async for delta in output:
                if delta.text:
                    print(delta.text, end="", flush=True)

                if delta.audio_tokens is None:
                    continue

                if torch.all(delta.audio_tokens == 1025):
                    break

                # print(f"{delta.audio_tokens=}")
                audio_tokens.append(delta.audio_tokens[:, None])
                audio_tensor = torch.cat(audio_tokens, dim=-1)
                print(f"{audio_tensor=}")

                if torch.all(delta.audio_tokens != 1024):
                    seq_len += 1
                    print(f"{delta.audio_tokens=} {seq_len=}")
                if seq_len > 0 and seq_len % CHUNK_SIZE == 0:
                    vq_code = (
                        revert_delay_pattern(audio_tensor, start_idx=seq_len - CHUNK_SIZE + 1)
                        .clip(0, 1023)
                        .to(device)
                    )

                    print(f"vq_code shape: {vq_code.shape} {vq_code=}")
                    waveform_numpy = serve_engine.audio_tokenizer.decode(vq_code.unsqueeze(0))[0, 0]
                    waveform_list.append(waveform_numpy)

                    # gen_audio_path = os.path.join(ASSETS_DIR, f"higgsv2_gen_audio_{i}_{seq_len}.wav")
                    # soundfile.write(gen_audio_path, waveform_numpy, serve_engine.audio_tokenizer.sampling_rate)
                    # info = soundfile.info(gen_audio_path, verbose=True)
                    # print(f"\nSaved audio chunk to {gen_audio_path}, duration: {info.duration:.2f} seconds")

            if seq_len > 0 and seq_len % CHUNK_SIZE != 0 and audio_tensor is not None:
                print(f"{audio_tensor=} {seq_len=}")
                vq_code = (
                    revert_delay_pattern(audio_tensor, start_idx=seq_len - seq_len % CHUNK_SIZE + 1)
                    .clip(0, 1023)
                    .to(device)
                )

                print(f"vq_code shape: {vq_code.shape} {vq_code=}")
                waveform_numpy = serve_engine.audio_tokenizer.decode(vq_code.unsqueeze(0))[0, 0]
                waveform_list.append(waveform_numpy)

            # new_audio = np.concatenate(waveform_list)

            for j, audio in enumerate(waveform_list):
                if j == 0:
                    new_audio = audio[:-cross_fade_samples]
                else:
                    cross_faded_overlap = (
                        waveform_list[j - 1][-cross_fade_samples:] * fade_out
                        + audio[:cross_fade_samples] * fade_in
                    )
                    new_audio = np.concatenate(
                        [
                            new_audio,
                            cross_faded_overlap,
                            audio[cross_fade_samples:-cross_fade_samples],
                        ]
                    )
            new_audio = np.concatenate([new_audio, audio[-cross_fade_samples:]])

            gen_audio_path = os.path.join(ASSETS_DIR, f"higgsv2_gen_audio_stream_{i}.wav")
            soundfile.write(
                gen_audio_path, new_audio, serve_engine.audio_tokenizer.sampling_rate, "PCM_16"
            )
            info = soundfile.info(gen_audio_path, verbose=True)
            print(info)
            print(f"\nSaved audio chunk to {gen_audio_path}, duration: {info.duration:.2f} seconds")
```