### PR TITLE
Add boson_multimodal.text_processing library

### DIFF
--- a/boson_multimodal/text_processing/transcript.py
+++ b/boson_multimodal/text_processing/transcript.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+
+# Use slots to save memory if Python version supports it.
+_dataclass_kwargs = {}
+if sys.version_info >= (3, 10):
+    _dataclass_kwargs["slots"] = True
+
+
+@dataclass(**_dataclass_kwargs)
+class Transcript:
+    """Represents an audio transcript with optional metadata.
+
+    Attributes:
+        config: Dictionary of key-value pairs parsed from the transcript header.
+        paragraphs: List of paragraphs, where each paragraph is a list of lines.
+    """
+
+    config: Optional[Dict[str, str]] = None
+    paragraphs: Optional[List[List[str]]] = None
+
+    @classmethod
+    def from_lines(
+        cls,
+        lines: Iterable[str],
+        parse_config: bool = True,
+    ) -> Transcript:
+        """Create a Transcript instance from an iterable of lines.
+
+        Parses optional config key-value pairs (if enabled) followed by paragraphs
+        separated by blank lines.
+
+        Args:
+            lines: An iterable of strings representing lines of text.
+            parse_config: Whether to parse config lines at the top of the input.
+
+        Returns:
+            A Transcript instance containing the parsed config and paragraphs.
+        """
+        config: Optional[Dict[str, str]] = None
+        paragraphs: Optional[List[List[str]]] = None
+        current_paragraph: List[str] = []
+        in_text_section = not parse_config  # Start instantly if config disabled.
+
+        for line in lines:
+            line = line.rstrip()
+
+            if not in_text_section:
+                if line == "":
+                    continue  # Skip leading empty lines.
+                if line.startswith("- "):
+                    # Config keys are always lowercase, must always begin with
+                    # a normal letter first, and then either letters or numbers.
+                    m = re.match(r"^- ([a-z][a-z0-9]*):\s*(.+)$", line)
+                    if m:
+                        if config is None:
+                            config = {}
+                        config[m.group(1)] = m.group(2).rstrip()
+                        continue
+                # First non-config line starts the text section.
+                in_text_section = True
+
+            # Handle paragraph accumulation.
+            if line == "":
+                if current_paragraph:
+                    if paragraphs is None:
+                        paragraphs = []
+                    paragraphs.append(current_paragraph)
+                    current_paragraph = []
+            else:
+                current_paragraph.append(line)
+
+        # Append final paragraph (if it wasn't already handled above).
+        if current_paragraph:
+            if paragraphs is None:
+                paragraphs = []
+            paragraphs.append(current_paragraph)
+
+        return cls(config=config, paragraphs=paragraphs)
+
+    @classmethod
+    def from_file(
+        cls,
+        filename: Union[str, Path],
+        parse_config: bool = True,
+    ) -> Transcript:
+        """Create a Transcript instance by reading from a text file.
+
+        Args:
+            filename: Path to the input text file.
+            parse_config: Whether to parse config lines at the top of the file.
+
+        Returns:
+            A Transcript instance containing the parsed config and paragraphs.
+        """
+        with open(filename, "rt", encoding="utf-8") as f:
+            return cls.from_lines(f, parse_config)
+
+    @classmethod
+    def from_text(
+        cls,
+        raw_text: str,
+        parse_config: bool = False,
+    ) -> Transcript:
+        """Create a Transcript instance from a raw text string.
+
+        Args:
+            raw_text: The full input text as a single string.
+            parse_config: Whether to parse config lines at the top of the input.
+
+        Returns:
+            A Transcript instance containing the parsed config and paragraphs.
+        """
+        return cls.from_lines(raw_text.splitlines(), parse_config)
+
+    def as_text(self) -> str:
+        """Serialize the Transcript instance into a formatted string.
+
+        Outputs config key-value pairs (if any) followed by paragraphs,
+        with blank lines separating the paragraphs.
+
+        Returns:
+            A string representation of the transcript.
+        """
+        lines: List[str] = []
+
+        if self.config:
+            for key, value in self.config.items():
+                lines.append(f"- {key}: {value}")
+
+        if self.paragraphs:
+            if self.config:
+                lines.append("")  # Blank line between config and paragraphs.
+
+            last_i = len(self.paragraphs) - 1
+            for i, paragraph in enumerate(self.paragraphs):
+                lines.extend(paragraph)
+                if i < last_i:
+                    lines.append("")  # Blank line between paragraphs.
+
+        return "\n".join(lines)


### PR DESCRIPTION
The new transcript library forms the basis for more robust and much easier voice transcript parsing and configuration.

It is not yet hooked into the code anywhere.

---

@sxjscience I created this library after our discussion in #52. As mentioned, my time is limited so I do not have time to hook it into your code in `generation.py` and the `vllm server` examples.

This library solves the following issues and bugs:

- Your current text parsing code is buggy and unreliable, doesn't split paragraphs at all (it tries to but it's bugged), and ends up doing 100-word splitting instead as a fallback.
- Voice configuration is currently very tedious via `profile.yaml`. This new library makes it possible to set the voice styles directly in the `.txt` file next to the audio file the transcript belongs to.

It's focused on speed and low memory usage so that it does the job reliably and "just works". It can parse transcripts from files, strings and iterables, and it can also output them back into a cleaned-up text format.

---

Usage for the new library is simple, and since you know your codebase very well, it will be best if you integrate it step by step into generate.py and the vLLM server.

Here is a demo showing the usage:

**Save this to `examples/voice_prompts/example.txt`:**

```
- speaker: He speaks with a clear British accent and a conversational, inquisitive tone. His delivery is articulate and at a moderate pace, and very clear audio.
- another: Here's another setting.

- third: There's a newline above this setting, demonstrating that users can put whitespace between settings, which they may do by accident, so we support it.

- another: This overwrites the value of "another" since later values for duplicate keys take precedence.

Once upon a time, there was a text-to-speech model named Higgs Audio V2.

And once upon another time, there was another paragraph right here!
```

**Save this to `examples/test_transcript.py`:** (Most of the code below is just demonstration-printing. Actual usage only requires one-line calls.)

```py
from pathlib import Path
from typing import Optional

from boson_multimodal.text_processing.transcript import Transcript


def show_transcript(title: str, transcript: Transcript) -> None:
    print(f"\n\n\n=== {title} ===")

    # Checking if a config exists.
    if transcript.config:
        print("\nConfig values:")
        for k, v in transcript.config.items():
            print(f"  {k} = {v}")
        
    # Example of just checking if a speaker-description has been set:
    speaker_style: Optional[str] = transcript.config.get("speaker") if transcript.config else None
    print("\nSpeaker style:")
    print(speaker_style)

    # Checking if text paragraphs exist (it might all have been empty!).
    if transcript.paragraphs:
        print("\nParagraphs:")
        for i, paragraph in enumerate(transcript.paragraphs, 1):
            print(f"* #{i}:")
            print("\n".join(paragraph))

    print("\nConverted back to text:\n***")
    print(transcript.as_text())
    print("***")


# Reading from a voice transcript. Resolves config variables by default.
transcript_txt = Path(__file__).resolve().parent / "voice_prompts/example.txt"
show_transcript("example.txt", Transcript.from_file(transcript_txt))


# Reading from a string. Doesn't resolve config variables by default.
# NOTE: This is intended to be used for all user-provided prompts via vLLM and Generate.py.
transcript_prompt = """
- speaker: This is not parsed, because from_text() doesn't resolve configs by default. But you can manually set a from_text() argument to tell it to do that if you want to.

This is an example of a user prompt, something that the user has asked the model to generate.
This is line two within the same paragraph.



Here is a new paragraph. Note that the excessive newlines above are handled.

And here is the final paragraph with some trailing newlines. The trailing newlines are ignored.



"""

show_transcript("from string", Transcript.from_text(transcript_prompt))
```

---

One of the most important things for you is this line:

```py
speaker_style: Optional[str] = transcript.config.get("speaker") if transcript.config else None
```

That's how you can cleanly fetch the "speaker style" value for voice transcripts, which eliminates the need for the clunky profile.yaml file. Although you might still prefer to keep that yaml file as a fallback option if no voice has been set within the text transcript itself.

After you fetch the `speaker_style` description from the Transcript object, you can check if a speaker style was set before you "include speaker style in system prompt":

```py
if speaker_style:
    print("Speaker style is not None and is not an empty string. Let's use it!")
```

---

**Here is an example of the clean parsing as a result of this processing:**

- Parsing of `example.txt` with config parsing enabled, meaning that it detects that a speaker style has been set for the provided audio clip:

```
Config values:
  speaker = He speaks with a clear British accent and a conversational, inquisitive tone. His delivery is articulate and at a moderate pace, and very clear audio.
  another = This overwrites the value of "another" since later values for duplicate keys take precedence.
  third = There's a newline above this setting, demonstrating that users can put whitespace between settings, which they may do by accident, so we support it.

Speaker style:
He speaks with a clear British accent and a conversational, inquisitive tone. His delivery is articulate and at a moderate pace, and very clear audio.

Paragraphs:
* #1:
Once upon a time, there was a text-to-speech model named Higgs Audio V2.
* #2:
And once upon another time, there was another paragraph right here!

Converted back to text:
***
- speaker: He speaks with a clear British accent and a conversational, inquisitive tone. His delivery is articulate and at a moderate pace, and very clear audio.
- another: This overwrites the value of "another" since later values for duplicate keys take precedence.
- third: There's a newline above this setting, demonstrating that users can put whitespace between settings, which they may do by accident, so we support it.

Once upon a time, there was a text-to-speech model named Higgs Audio V2.

And once upon another time, there was another paragraph right here!
***
```

- Parsing from string, which is intended to be used for all user-provided prompts, to cleanly chunk the text into very clean paragraphs for further post-processing afterwards.

```
Speaker style:
None

Paragraphs:
* #1:
- speaker: This is not parsed, because from_text() doesn't resolve configs by default. But you can manually set a from_text() argument to tell it to do that if you want to.
* #2:
This is an example of a user prompt, something that the user has asked the model to generate.
This is line two within the same paragraph.
* #3:
Here is a new paragraph. Note that the excessive newlines above are handled.
* #4:
And here is the final paragraph with some trailing newlines. The trailing newlines are ignored.

Converted back to text:
***
- speaker: This is not parsed, because from_text() doesn't resolve configs by default. But you can manually set a from_text() argument to tell it to do that if you want to.

This is an example of a user prompt, something that the user has asked the model to generate.
This is line two within the same paragraph.

Here is a new paragraph. Note that the excessive newlines above are handled.

And here is the final paragraph with some trailing newlines. The trailing newlines are ignored.
***
```