### PR TITLE
Remove unused import to avoid library conflict

### DIFF
--- a/boson_multimodal/__init__.py
+++ b/boson_multimodal/__init__.py
@@ -1,1 +1,0 @@
-from .model.higgs_audio import HiggsAudioConfig, HiggsAudioModel


### PR DESCRIPTION
The vllm repo will reuse the audio tokenizer code, but the current import will trigger error because of the transformer version mismatch. To avoid this, we should not import HiggsAudioModel at the init.