### PR TITLE
Use CUDA for audio decoding unless you are on 'mps' and need to use CPU

### DIFF
--- a/boson_multimodal/audio_processing/higgs_audio_tokenizer.py
+++ b/boson_multimodal/audio_processing/higgs_audio_tokenizer.py
@@ -304,7 +304,7 @@ class HiggsAudioTokenizer(nn.Module):
         quantized_acoustic = self.fc_post2(quantized).transpose(1, 2)
 
         o = self.decoder_2(quantized_acoustic)
-        return o.cpu().numpy()
+        return o.detach().cpu().numpy()
 
 
 def load_higgs_audio_tokenizer(tokenizer_name_or_path, device="cuda"):

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -192,7 +192,7 @@ class HiggsAudioModelClient:
         else:
             if device is not None:
                 self._device = device
-            else: # We get to choose the device
+            else:  # We get to choose the device
                 # Prefer CUDA over MPS (Apple Silicon GPU) over CPU if available
                 if torch.cuda.is_available():
                     self._device = "cuda:0"
@@ -208,7 +208,7 @@ class HiggsAudioModelClient:
             self._audio_tokenizer = load_higgs_audio_tokenizer(audio_tokenizer, device=audio_tokenizer_device)
         else:
             self._audio_tokenizer = audio_tokenizer
-            
+
         self._model = HiggsAudioModel.from_pretrained(
             model_path,
             device_map=self._device,
@@ -371,13 +371,13 @@ class HiggsAudioModelClient:
         logger.info(f"========= Final Text output =========")
         logger.info(self._tokenizer.decode(outputs[0][0]))
         concat_audio_out_ids = torch.concat(audio_out_ids_l, dim=1)
-        
+
         # Fix MPS compatibility: detach and move to CPU before decoding
         if concat_audio_out_ids.device.type in ["mps", "cuda"]:
             concat_audio_out_ids_cpu = concat_audio_out_ids.detach().cpu()
         else:
             concat_audio_out_ids_cpu = concat_audio_out_ids
-        
+
         concat_wv = self._audio_tokenizer.decode(concat_audio_out_ids_cpu.unsqueeze(0))[0, 0]
         text_result = self._tokenizer.decode(outputs[0][0])
         return concat_wv, sr, text_result
@@ -682,7 +682,7 @@ def main(
         max_new_tokens=max_new_tokens,
         use_static_kv_cache=use_static_kv_cache,
     )
-    
+
     pattern = re.compile(r"\[(SPEAKER\d+)\]")
 
     if os.path.exists(transcript):

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -373,7 +373,7 @@ class HiggsAudioModelClient:
         concat_audio_out_ids = torch.concat(audio_out_ids_l, dim=1)
 
         # Fix MPS compatibility: detach and move to CPU before decoding
-        if concat_audio_out_ids.device.type in ["mps", "cuda"]:
+        if concat_audio_out_ids.device.type == "mps":
             concat_audio_out_ids_cpu = concat_audio_out_ids.detach().cpu()
         else:
             concat_audio_out_ids_cpu = concat_audio_out_ids

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -616,10 +616,10 @@ def prepare_generation_context(scene_prompt, ref_audio, ref_audio_in_system_mess
     help="Whether to use static KV cache for faster generation. Only works when using GPU.",
 )
 @click.option(
-    "--acc",
+    "--device",
     type=click.Choice(["auto", "cuda", "mps", "none"]),
     default="auto",
-    help="Device acceleration mode: 'auto' (pick best available), 'cuda', 'mps', or 'none' (CPU only).",
+    help="Device to use: 'auto' (pick best available), 'cuda', 'mps', or 'none' (CPU only).",
 )
 def main(
     model_path,
@@ -642,11 +642,11 @@ def main(
     device_id,
     out_path,
     use_static_kv_cache,
-    acc,
+    device,
 ):
     # specifying a device_id implies CUDA
     if device_id is None:
-        if acc == "auto":
+        if device == "auto":
             if torch.cuda.is_available():
                 device_id = 0
                 device = "cuda:0"
@@ -656,10 +656,10 @@ def main(
             else:
                 device_id = None
                 device = "cpu"
-        elif acc == "cuda":
+        elif device == "cuda":
             device_id = 0
             device = "cuda:0"
-        elif acc == "mps":
+        elif device == "mps":
             device_id = None
             device = "mps"
         else:

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -180,20 +180,35 @@ class HiggsAudioModelClient:
         self,
         model_path,
         audio_tokenizer,
+        device=None,
         device_id=None,
         max_new_tokens=2048,
         kv_cache_lengths: List[int] = [1024, 4096, 8192],  # Multiple KV cache sizes,
         use_static_kv_cache=False,
     ):
-        if device_id is None:
-            self._device = "cuda" if torch.cuda.is_available() else "cpu"
+        # Use explicit device if provided, otherwise try CUDA/MPS/CPU
+        if device_id is not None:
+            device = f"cuda:{device_id}"
         else:
-            self._device = f"cuda:{device_id}"
-        self._audio_tokenizer = (
-            load_higgs_audio_tokenizer(audio_tokenizer, device=self._device)
-            if isinstance(audio_tokenizer, str)
-            else audio_tokenizer
-        )
+            if device is not None:
+                self._device = device
+            else: # We get to choose the device
+                # Prefer CUDA over MPS (Apple Silicon GPU) over CPU if available
+                if torch.cuda.is_available():
+                    self._device = "cuda:0"
+                elif torch.backends.mps.is_available():
+                    self._device = "mps"
+                else:
+                    self._device = "cpu"
+
+        logger.info(f"Using device: {self._device}")
+        if isinstance(audio_tokenizer, str):
+            # For MPS, use CPU due to embedding operation limitations in quantization layers
+            audio_tokenizer_device = "cpu" if self._device == "mps" else self._device
+            self._audio_tokenizer = load_higgs_audio_tokenizer(audio_tokenizer, device=audio_tokenizer_device)
+        else:
+            self._audio_tokenizer = audio_tokenizer
+            
         self._model = HiggsAudioModel.from_pretrained(
             model_path,
             device_map=self._device,
@@ -356,7 +371,14 @@ class HiggsAudioModelClient:
         logger.info(f"========= Final Text output =========")
         logger.info(self._tokenizer.decode(outputs[0][0]))
         concat_audio_out_ids = torch.concat(audio_out_ids_l, dim=1)
-        concat_wv = self._audio_tokenizer.decode(concat_audio_out_ids.unsqueeze(0))[0, 0]
+        
+        # Fix MPS compatibility: detach and move to CPU before decoding
+        if concat_audio_out_ids.device.type in ["mps", "cuda"]:
+            concat_audio_out_ids_cpu = concat_audio_out_ids.detach().cpu()
+        else:
+            concat_audio_out_ids_cpu = concat_audio_out_ids
+        
+        concat_wv = self._audio_tokenizer.decode(concat_audio_out_ids_cpu.unsqueeze(0))[0, 0]
         text_result = self._tokenizer.decode(outputs[0][0])
         return concat_wv, sr, text_result
 
@@ -593,6 +615,12 @@ def prepare_generation_context(scene_prompt, ref_audio, ref_audio_in_system_mess
     default=1,
     help="Whether to use static KV cache for faster generation. Only works when using GPU.",
 )
+@click.option(
+    "--acc",
+    type=click.Choice(["auto", "cuda", "mps", "none"]),
+    default="auto",
+    help="Device acceleration mode: 'auto' (pick best available), 'cuda', 'mps', or 'none' (CPU only).",
+)
 def main(
     model_path,
     audio_tokenizer,
@@ -614,25 +642,47 @@ def main(
     device_id,
     out_path,
     use_static_kv_cache,
+    acc,
 ):
+    # specifying a device_id implies CUDA
     if device_id is None:
-        if torch.cuda.is_available():
+        if acc == "auto":
+            if torch.cuda.is_available():
+                device_id = 0
+                device = "cuda:0"
+            elif torch.backends.mps.is_available():
+                device_id = None  # MPS doesn't use device IDs like CUDA
+                device = "mps"
+            else:
+                device_id = None
+                device = "cpu"
+        elif acc == "cuda":
             device_id = 0
             device = "cuda:0"
+        elif acc == "mps":
+            device_id = None
+            device = "mps"
         else:
             device_id = None
             device = "cpu"
     else:
         device = f"cuda:{device_id}"
-    audio_tokenizer = load_higgs_audio_tokenizer(audio_tokenizer, device=device)
+    # For MPS, use CPU for audio tokenizer due to embedding operation limitations
+    audio_tokenizer_device = "cpu" if device == "mps" else device
+    audio_tokenizer = load_higgs_audio_tokenizer(audio_tokenizer, device=audio_tokenizer_device)
 
+    # Disable static KV cache on MPS since it relies on CUDA graphs
+    if device == "mps" and use_static_kv_cache:
+        use_static_kv_cache = False
     model_client = HiggsAudioModelClient(
         model_path=model_path,
         audio_tokenizer=audio_tokenizer,
+        device=device,
         device_id=device_id,
         max_new_tokens=max_new_tokens,
         use_static_kv_cache=use_static_kv_cache,
     )
+    
     pattern = re.compile(r"\[(SPEAKER\d+)\]")
 
     if os.path.exists(transcript):
@@ -647,7 +697,6 @@ def main(
         scene_prompt = None
 
     speaker_tags = sorted(set(pattern.findall(transcript)))
-
     # Perform some basic normalization
     transcript = normalize_chinese_punctuation(transcript)
     # Other normalizations (e.g., parentheses and other symbols. Will be improved in the future)


### PR DESCRIPTION
## Summary
This PR optimizes CUDA performance by removing an unnecessary CPU transfer for audio decoding that was only needed for MPS devices.

Previously, both CUDA and MPS tensors were being moved to CPU for audio decoding. The CPU transfer was only necessary for MPS devices due to embedding operation limitations in quantization layers. This change ensures CUDA tensors remain on GPU for decoding while maintaining MPS compatibility.

## Changes
- Modified the device check in `examples/generation.py` to only move tensors to CPU for MPS devices
- CUDA devices now keep tensors on GPU for audio decoding, improving performance

## Testing
- Maintains existing MPS compatibility 
- Improves performance for CUDA users by avoiding unnecessary GPU->CPU->GPU transfers

Follow-up to address performance optimization opportunity identified in the original MPS compatibility fix.